### PR TITLE
Target github profile via an environment variable

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -10,14 +10,13 @@ import (
 )
 
 func main() {
-	cfg := config.New()
 	hdl := routes.NewHandler()
 	srv := http.Server{
-		Addr:    fmt.Sprintf(":%d", cfg.Port),
+		Addr:    fmt.Sprintf(":%d", config.ServerPort),
 		Handler: hdl,
 	}
 
-	fmt.Printf("starting server at: %s\n", srv.Addr)
+	fmt.Printf("starting server at: %v\n", srv.Addr)
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		fmt.Printf("error starting server: %s\n", err)
 		os.Exit(1)

--- a/config/config.go
+++ b/config/config.go
@@ -8,10 +8,11 @@ import (
 
 var (
 	ServerPort = NewEnv("SERVER_PORT", 8080)
+	GHProfile  = NewEnv("GH_PROFILE", "keithhand")
 )
 
 type EnvTypes interface {
-	int
+	int | string
 }
 
 func NewEnv[T EnvTypes](key string, defaultValue T) T {

--- a/routes/github.go
+++ b/routes/github.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"log"
 	"net/http"
+
+	"khand.dev/khand.dev/config"
 )
 
 var repos []gitHubRepo
@@ -39,7 +41,7 @@ func (h projects) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user := "keithhand"
+	user := config.GHProfile
 	repoApi := fmt.Sprintf("https://api.github.com/users/%s/repos", user)
 	resp, err := http.Get(repoApi)
 	if err != nil {


### PR DESCRIPTION
This updates the way configs were set to make it easier to add new configs in the future. String and int variables now work and can be accessed via the `config.Config` struct that gets instantiated on package import.

Closes:
- #2
- #4